### PR TITLE
Fix broken image and reference formatting

### DIFF
--- a/index.html
+++ b/index.html
@@ -112,7 +112,7 @@
                     
                 </div>
                 <div class="card">
-                    <img src="DES222%20Image%20assignment%20one/Rectangle%209.png">
+                    <img src="DES222%20Images%20assignment%20one/Rectangle%209.png">
                     <div class="card-overlay">
                         <div class="card-overlay__content">
                             The corporatocracy will also construct both predictive policing algorithms and economic algorithms, and then manipulate these two algorithms as a method of social control.
@@ -133,14 +133,15 @@
                 <img id="referenceListImage" src="DES222%20Images%20assignment%20one/REFERENCE%20LIST.png">
             </div>
             <div id="references">
-                REFERENCE LIST
-                Amine, R. (2023, October 1).  Smart Cities: Development and Benefits. SpringerNature Link. https://link.springer.com/chapter/10.1007/978-3-031-35664-3_4
-                Brannon, M, Monica. (2017, March 1). Datafied and Divided: Techno–Dimensions of Inequality in American Cities. SageJournals. https://journals.sagepub.com/doi/full/10.1111/cico.12220
-                Cavalcanti, P, R & Garmany, J. (2020). The Politics of Crime and Militarised Policing in Brazil. International Journal for Crime, Justice and Social Democracy. https://www.crimejusticejournal.com/article/download/1157/912
-                Christl, W. (2017, October). How Companies Use Personal Data Against People. Cracked Labs. https://crackedlabs.org/dl/CrackedLabs_Christl_DataAgainstPeople.pdf
-                Correio da Manhã. (1964). Deposition of the João Goulart Government – Coup of 1964 [Photograph]. Picryl. https://picryl.com/media/deposicao-do-governo-joao-goulart-golpe-de-1964-13-245f53
-                MelbourneCBDTowing. (N.D). Tow Trucks Melbourne  [Photograph]. MelbourneCBDTowing. https://www.melbournecbdtowing.net.au/tow-trucks-melbourne/
-                Tomin, L. (2021, April 14). Surveillance City. Digital Transformation of Urban Governance in Autocratic Regimes. ResearchGate. https://www.researchgate.net/publication/351060256_Surveillance_City_Digital_Transformation_of_Urban_Governance_in_Autocratic_Regimes
+                <ul class="reference-list">
+                    <li>Amine, R. (2023, October 1).  Smart Cities: Development and Benefits. SpringerNature Link. https://link.springer.com/chapter/10.1007/978-3-031-35664-3_4</li>
+                    <li>Brannon, M, Monica. (2017, March 1). Datafied and Divided: Techno–Dimensions of Inequality in American Cities. SageJournals. https://journals.sagepub.com/doi/full/10.1111/cico.12220</li>
+                    <li>Cavalcanti, P, R & Garmany, J. (2020). The Politics of Crime and Militarised Policing in Brazil. International Journal for Crime, Justice and Social Democracy. https://www.crimejusticejournal.com/article/download/1157/912</li>
+                    <li>Christl, W. (2017, October). How Companies Use Personal Data Against People. Cracked Labs. https://crackedlabs.org/dl/CrackedLabs_Christl_DataAgainstPeople.pdf</li>
+                    <li>Correio da Manhã. (1964). Deposition of the João Goulart Government – Coup of 1964 [Photograph]. Picryl. https://picryl.com/media/deposicao-do-governo-joao-goulart-golpe-de-1964-13-245f53</li>
+                    <li>MelbourneCBDTowing. (N.D). Tow Trucks Melbourne  [Photograph]. MelbourneCBDTowing. https://www.melbournecbdtowing.net.au/tow-trucks-melbourne/</li>
+                    <li>Tomin, L. (2021, April 14). Surveillance City. Digital Transformation of Urban Governance in Autocratic Regimes. ResearchGate. https://www.researchgate.net/publication/351060256_Surveillance_City_Digital_Transformation_of_Urban_Governance_in_Autocratic_Regimes</li>
+                </ul>
          </div>
     </div>
     <script src="index.js"></script>

--- a/style.css
+++ b/style.css
@@ -63,7 +63,7 @@ body {
  */
 
 .col-bg {
-  grid-row: 1 / -1;          /* from the top row to the last row */
+  grid-row: 1 / 999;          /* from the top row to the last row */
   background: var(--col-bg); /* your red */
   position: relative;        /* <-- ensures z-index takes effect */
   z-index: 1;                /* sits behind triangles/banner/markers/cols */
@@ -401,3 +401,21 @@ body {
   #backgroundImage img { width: 100%; height: auto; display: block; }
 }
 
+#references {
+  max-width: 100%;
+}
+
+.reference-list {
+  list-style-type: none; /* removes bullets */
+  padding: 0;
+  margin: 0;
+  max-width: 100%;
+  word-wrap: break-word;      /* legacy, widely supported */
+  overflow-wrap: anywhere;    /* modern, flexible */
+}
+
+.reference-list li {
+  padding-left: 2em;
+  text-indent: -2em;
+  margin-bottom: 1em; /* spacing between refs */
+}


### PR DESCRIPTION
Corrects the path for the missing image (was missing the 's' at the end of the word 'images') and adds some nice formatting for the reference list.  Also makes the red banners go all the way to the bottom in columns 2 and 3